### PR TITLE
修复了上拉加载和下拉刷新显示的2个问题

### DIFF
--- a/smart-swipe/src/main/java/com/billy/android/swipe/refresh/ClassicFooter.java
+++ b/smart-swipe/src/main/java/com/billy/android/swipe/refresh/ClassicFooter.java
@@ -66,6 +66,8 @@ public class ClassicFooter extends ClassicHeader implements SmartSwipeRefresh.Sm
     @Override
     public void setNoMoreData(boolean noMoreData) {
         this.mNoMoreData = noMoreData;
-        setText(R.string.ssr_footer_no_more_data);
+        //修复了上拉加载始终显示"已全部加载完成"的问题.
+        if (noMoreData)
+            setText(R.string.ssr_footer_no_more_data);
     }
 }

--- a/smart-swipe/src/main/java/com/billy/android/swipe/refresh/ClassicHeader.java
+++ b/smart-swipe/src/main/java/com/billy/android/swipe/refresh/ClassicHeader.java
@@ -127,7 +127,8 @@ public class ClassicHeader extends RelativeLayout implements SmartSwipeRefresh.S
 
     @Override
     public void onReset() {
-
+        //修复了:先下拉刷新完成(此时显示为刷新完成),然后调用 startRefresh 时,看到的不是"下拉刷新"而是"刷新完成"的问题.
+        setText(com.billy.android.swipe.R.string.ssr_header_pulling);
     }
 
     @Override


### PR DESCRIPTION
##### 问题1:上拉加载始终显示"已全部加载完成"的问题.
###### 问题复现步骤:
1. 上拉加载数据
2. 观察显示的提示文本
3. 上拉加载完全部数据后
4. 再观察显示的提示文本.

##### 问题2:先下拉刷新完成,然后调用 startRefresh后,看到的不是"下拉刷新"而是"刷新完成"的问题
###### 问题复现步骤:
1. 先下拉刷新完成(此时提示为刷新完成),
2. 然后调用 startRefresh 
3. 观察提示看到的不是"下拉刷新"而是"刷新完成"