### PR TITLE
fixed startRefresh hint display error

### DIFF
--- a/smart-swipe/src/main/java/com/billy/android/swipe/refresh/ClassicHeader.java
+++ b/smart-swipe/src/main/java/com/billy/android/swipe/refresh/ClassicHeader.java
@@ -127,7 +127,9 @@ public class ClassicHeader extends RelativeLayout implements SmartSwipeRefresh.S
 
     @Override
     public void onReset() {
-
+        //修复了:先下拉刷新完成(此时显示为刷新完成),然后调用 startRefresh 时,看到的不是"下拉刷新"而是"刷新完成"的问题.
+        //fix:first pull to refresh finished(hint:Refresh Success),then invoke startRefresh,now will allways see the 'Refresh Success'.so reset the text.
+        setText(com.billy.android.swipe.R.string.ssr_header_pulling);
     }
 
     @Override


### PR DESCRIPTION
##### 问题2:先下拉刷新完成,然后调用 startRefresh后,看到的不是"下拉刷新"而是"刷新完成"的问题

###### 问题复现步骤:
1. 先`下拉刷新`完成(此时提示为刷新完成)
    first `pull to refresh` finished(hint:Refresh Success)
2. 然后调用 `startRefresh `
   then invoke `startRefresh`,
3. 观察提示看到的不是"下拉刷新"而是"刷新完成"
  now will allways see the 'Refresh Success'. expect 'Pull To Refresh'.